### PR TITLE
Configuration refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,29 @@ Add the facade to your class aliases array in `config/app.php`:
 
     'DocumentMapper' => ChefsPlate\ODM\Facades\DocumentMapper::class,
 
-You should now be able to use the **mongodb** driver in `config/database.php`.
+Ensure you have connection details for the **mongodb** driver setup in `config/database.php`.
+See `vendor/chefsplate/laravel-odm/config/database.php` for a more complete example.
 
-    'mongodb' => array(
-        'driver'   => 'mongodb',
-        'dsn'      => 'mongodb://127.0.0.1:27017',
-        'database' => 'database_name'
-    ),
+    'mongodb' => [
+        'driver'        => 'mongodb',
+        'dsn'           => 'mongodb://localhost:27017',
+        'database'      => 'mydb', // Default DB to perform queries against (not authenticate against)
+        'retryConnect'  => 2, // Number of connection retry attempts before failing (doctrine feature)
+        'retryQuery'    => 1, // Number of query retry attempts before failing (doctrine feature)
+        'options'       => [
+    
+        ],
+        'driverOptions' => [
 
+        ]
+    ]
 The format for the DSN is:
 `mongodb://[username:password@]host1[:port1][,host2[:port2:],...]/db`
+
+Copy the default doctrine and ide-odm-helper config files to your app's config
+`cp vendor/chefsplate/laravel-odm/config/doctrine.php config/doctrine.php`
+`cp vendor/chefsplate/laravel-odm/config/ide-odm-helper.php config/ide-odm-helper.php`
+Modify to suit your environment
 
 Eloquent-like Wrapper Methods
 -----------------------------

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,7 @@
   "require": {
     "php": ">=5.4.0",
     "laravel/framework": "5.3.*|5.4.*",
-    "ext-mongo": "*",
     "doctrine/mongodb-odm": "^1.1",
-    "mongodb/mongodb": "^1.1",
     "chefsplate/mongodb-odm-softdelete": "^0.1",
     "phpdocumentor/reflection-docblock": "^3.1"
   },

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'connections' => [
+        'mongodb'   => [
+            'driver'        => 'mongodb',
+            'dsn'           => 'mongodb://localhost:27017',
+            'database'      => 'mydb', // Default DB to perform queries against (not authenticate against)
+            'retryConnect'  => 2, // Number of connection retry attempts before failing (doctrine feature)
+            'retryQuery'    => 1, // Number of query retry attempts before failing (doctrine feature)
+            'options'       => [
+                // mapped to MongoClient $options
+                'connectTimeoutMS'  => 1000, // Connection attempt timeout (milliseconds)
+                'wTimeoutMS'        => 2500, // DB write attempt timeout (milliseconds)
+                'socketTimeoutMS'   => 10000, // Client side socket timeout (milliseconds)
+                'w'                 => 'majority', // Default write concern (normally w=1)
+                'readPreference'    => \MongoClient::RP_PRIMARY_PREFERRED, // Default read preference
+            ],
+            'driverOptions' => [ // mapped to MongoClient $driverOptions (e.g. for SSL stream context)
+
+            ]
+        ]
+    ]
+];

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -1,0 +1,53 @@
+<?php
+
+return [
+    
+    // The name of the connection Doctrine should use (from database.php)
+    'connection' => 'mongodb',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Doctrine Document Mapper Settings
+    |--------------------------------------------------------------------------
+    |
+    | Configure the Doctrine ODM settings here. Change the
+    | paths setting to the appropriate path and replace App namespace
+    | by your own namespace.
+    |
+    | --> Warning: Proxy auto generation should only be enabled in dev!
+    |
+    */
+
+    'doctrine_dm' => [
+
+        /* A list of entities */
+        'paths' => [
+            base_path('app/Entities')
+        ],
+
+        'proxies' => [
+            'namespace'     => 'Proxies',
+            'path'          => storage_path('proxies'),
+            'auto_generate' => env('DOCTRINE_PROXY_AUTOGENERATE', false)
+        ],
+
+        'hydrators' => [
+            'namespace' => 'Hydrators',
+            'path'      => storage_path('hydrators'),
+        ],
+
+        // TODO: support multiple metadata implementations
+        'meta'    => env('DOCTRINE_METADATA', 'annotations'),
+
+    ],
+
+    // Document Mapper Settings specific to our Laravel implementation
+    'laravel_dm' => [
+
+        'soft_deletes' => [
+            'enabled'    => true,
+            'field_name' => 'deleted_at'
+        ]
+
+    ],
+];

--- a/src/Providers/DocumentMapperServiceProvider.php
+++ b/src/Providers/DocumentMapperServiceProvider.php
@@ -33,31 +33,48 @@ class DocumentMapperServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('DocumentMapper', function ($app) {
-            $laravel_config = config('doctrine');
-            $config         = new Configuration();
-            $config->setProxyDir($laravel_config['proxies']['path']);
-            $config->setProxyNamespace($laravel_config['proxies']['namespace']);
-            $config->setHydratorDir($laravel_config['hydrators']['path']);
-            $config->setHydratorNamespace($laravel_config['hydrators']['namespace']);
-            $config->setMetadataDriverImpl(AnnotationDriver::create($laravel_config['paths']));
-            $config->setDefaultDB($laravel_config['mongodb']['database']);
-            $config->setMetadataCacheImpl(new VoidCache());
+            
+            // Retrieve all of the required configuration
+            $app_config = config('doctrine');
+            $doctrine_dm_config = $app_config['doctrine_dm'];
+            $laravel_dm_config = $app_config['laravel_dm'];
+            $conn_config = config('database.connections.'. $app_config['connection']);
 
+            // Setup the Doctrine configuration object
+            $dm_config = new Configuration();
+            $dm_config->setProxyDir($doctrine_dm_config['proxies']['path']);
+            $dm_config->setProxyNamespace($doctrine_dm_config['proxies']['namespace']);
+            $dm_config->setHydratorDir($doctrine_dm_config['hydrators']['path']);
+            $dm_config->setHydratorNamespace($doctrine_dm_config['hydrators']['namespace']);
+            $dm_config->setMetadataDriverImpl(AnnotationDriver::create($doctrine_dm_config['paths']));
+            $dm_config->setDefaultDB($conn_config['database']);
+            $dm_config->setMetadataCacheImpl(new VoidCache());
+
+            // Init annotation driver
             AnnotationDriver::registerAnnotationClasses();
 
             // register custom types
             Type::registerType(CarbonDateType::CARBON, CarbonDateType::class);
             Type::registerType(CarbonDateArrayType::CARBON_ARRAY, CarbonDateArrayType::class);
 
-            $dsn           = config('database.connections.mongodb.dsn');
-            $connection    = new Connection($dsn);
-            $event_manager = new EventManager();
+            // Setup the Doctrine connection object
+            $connection_config = new \Doctrine\MongoDB\Configuration();
+            $connection_config->setRetryConnect($conn_config['retryConnect']);
+            $connection_config->setRetryQuery($conn_config['retryQuery']);
+
+            $connection = new Connection(
+                $conn_config['dsn'],
+                $conn_config['options'],
+                $connection_config,
+                null, // Event Manager
+                $conn_config['driverOptions']
+            );
 
             return new DocumentMapperService(
                 $connection,
-                $config,
-                $event_manager,
-                $laravel_config
+                $dm_config,
+                new EventManager(),
+                $laravel_dm_config
             );
         });
     }


### PR DESCRIPTION
Re: #4
There is still a lot of work to be done to support all of the various Doctrine Document Mapper configuration options, but this refactor gives a lot more support for various MongoClient and driver options such as writeConcern, readPreference, connection retries, etc...  